### PR TITLE
Path patch

### DIFF
--- a/R/make_project.R
+++ b/R/make_project.R
@@ -356,7 +356,7 @@ make_project <- function(
     usethis::use_package("tidyverse", type = "suggests")
   })
 
-  browser()
+  # browser()
 
   # Create vignettes/.gitignore & write "*.html" & "*.R"
   writeLines("*.html\n*.R", con = "vignettes/.gitignore")

--- a/R/make_project.R
+++ b/R/make_project.R
@@ -262,7 +262,9 @@ make_project <- function(
   invisible({
     # Remove default .gitingore
     # file.remove(paste0(path, "/.gitignore"))
-    file.remove(file.path(path, ".gitignore"))
+    if (file.exists(file.path(path, ".gitignore"))) {
+      file.remove(file.path(path, ".gitignore"))
+    }
     # Replace .gitignore
     file.copy(
       from = ign_path,

--- a/inst/gists/analysis_qmd_with_example.qmd
+++ b/inst/gists/analysis_qmd_with_example.qmd
@@ -116,7 +116,7 @@ As can be seen in @fig-figure-1 ...
 
 # References {.unnumbered}
 
-```{r}
+```{r, make-references}
 #| include: false
 
 # automatically create a bib database for loaded R packages & rUM

--- a/inst/gists/analysis_qmd_wo_example.qmd
+++ b/inst/gists/analysis_qmd_wo_example.qmd
@@ -86,7 +86,7 @@ As can be seen in @fig-figure-1 ...
 
 # References {.unnumbered}
 
-```{r}
+```{r, make-references}
 #| include: false
 
 # automatically create a bib database for loaded R packages & rUM

--- a/inst/gists/analysis_rmd_with_example.Rmd
+++ b/inst/gists/analysis_rmd_with_example.Rmd
@@ -112,7 +112,7 @@ See Figure \@ref(fig:figure1) or [Figure 1](#fig:figure1)
 
 # References {-}
 
-```{r include=FALSE}
+```{r, make-references, include=FALSE}
 # automatically create a bib database for loaded R packages & rUM
 knitr::write_bib(
   c(

--- a/inst/gists/analysis_rmd_wo_example.Rmd
+++ b/inst/gists/analysis_rmd_wo_example.Rmd
@@ -84,7 +84,7 @@ See Figure \@ref(fig:figure1) or [Figure 1](#fig:figure1)
 
 # References {-}
 
-```{r include=FALSE}
+```{r, make-references, include=FALSE}
 # automatically create a bib database for loaded R packages & rUM
 knitr::write_bib(
   c(

--- a/yaml_parsing.R
+++ b/yaml_parsing.R
@@ -1,0 +1,47 @@
+
+# the whole deal
+yaml_string <- "---\r\ntitle: \"your_title_goes_here\"\r\nauthor: \"your_name_goes_here\"\r\ndate: last-modified\r\nformat:\r\n  html:\r\n    embed-resources: true\r\n    theme:\r\n      - default\r\n      - custom.scss\r\nknitr:\r\n  opts_chunk:        ############ set global options ############\r\n    collapse: true   # keep code from blocks together (if shown)\r\n    echo: false      # don't show code\r\n    message: true    # show messages\r\n    warning: true    # show warnings\r\n    error: true      # show error messages\r\n    comment: \"\"      # don't show ## with printed output\r\n    dpi: 100         # image resolution (typically 300 for publication)\r\n    fig-width: 6.5   # figure width\r\n    fig-height: 4.0  # figure height\r\n    R.options:    \r\n      digits: 3    # round to three digits\r\neditor: source\r\nbibliography: [references.bib, packages.bib]\r\ncsl: the-new-england-journal-of-medicine.csl\r\n---"
+ 
+yaml_less <- "format:\r\n  html:\r\n    embed-resources: true\r\n    theme:\r\n      - default\r\n      - custom.scss"
+ 
+# what we're looking for (non-Windows)
+qmd_pattern <- "format:\n  html:\n    embed-resources: true\n    theme:\n      - default\n      - custom.scss"
+
+# Replace that with this:
+qmd_replacement <- "output: rmarkdown::html_vignette\nvignette: >\n  %\\\\VignetteIndexEntry{your_title_goes_here}\n  %\\\\VignetteEngine{knitr::rmarkdown}\n  %\\\\VignetteEncoding{UTF-8}\n"
+ 
+ 
+# what is read in Windows
+pattern_win <- "format:\r\n  html:\r\n    embed-resources: true\r\n    theme:\r\n      - default\r\n      - custom.scss"
+
+# stringr::str_replace_all(pattern, '\n', '\r\n')
+
+if (.Platform$OS.type == 'windows') {
+  qmd_pattern <- stringr::str_replace_all(qmd_pattern, '\n', '\r\n')
+  qmd_replacement <- stringr::str_replace_all(qmd_replacement, '\n', '\r\n')
+}
+
+stringr::str_replace(yaml_string, qmd_pattern, qmd_replacement)
+stringr::str_replace(yaml_less, qmd_pattern, qmd_replacement)
+
+#################################################################################
+
+# what Windows sees
+yaml_rmd <- "---\r\ntitle: \"your_title_goes_here\"\r\nauthor: \"your_name_goes_here\"\r\ndate: \"`r Sys.Date()`\"\r\noutput:\r\n  bookdown::html_document2:\r\n    number_sections: false\r\nbibliography: [references.bib, packages.bib]\r\ncsl: the-new-england-journal-of-medicine.csl\r\n---"
+
+# what Windows sees reduced
+yaml_rmd_less <- "output:\r\n  bookdown::html_document2:\r\n    number_sections: false\r\n"
+
+# what will be replaced
+rmd_pattern <- "output:\n  bookdown::html_document2:\n    number_sections: false\n"
+
+# what it'll be replaced with
+rmd_replacement <- "output: rmarkdown::html_vignette\nvignette: >\n  %\\\\VignetteIndexEntry{your_title_goes_here}\n  %\\\\VignetteEngine{knitr::rmarkdown}\n  %\\\\VignetteEncoding{UTF-8}\n"
+
+if (.Platform$OS.type == 'windows') {
+  rmd_pattern <- stringr::str_replace_all(rmd_pattern, '\n', '\r\n')
+  rmd_replacement <- stringr::str_replace_all(rmd_replacement, '\n', '\r\n')
+}
+
+stringr::str_replace(yaml_rmd, rmd_pattern, rmd_replacement)
+stringr::str_replace(yaml_rmd_less, rmd_pattern, rmd_replacement)


### PR DESCRIPTION
- adding argument validation
- changed from `paste0(path, ...)` to `file.path(path, ..)`
- added YAML parsing logic for `vignette = TRUE` to detect `.Platform$OS.type` and convert `\n` line returns to `\r\n` for Windows environments