### PR TITLE
feat(slides): open external links in new tab by default

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -3,8 +3,8 @@
 on:
   push:
     branches: [main, master]
-  pull_request:
-    branches: [main, master]
+  # pull_request:
+  #   branches: [main, master]
   release:
     types: [published]
   workflow_dispatch:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rUM
 Title: R Templates from the University of Miami
-Version: 2.3.0
+Version: 2.3.1
 Authors@R: 
     c(
       person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# rUM 2.3.1 (patch release)
+
+## Enhancements
+* Adding to slides templates to open links in new tab and add default link icon:
+```
+format: 
+  revealjs:
+    link-external-newwindow: true
+    link-external-icon: false
+```
+
+
 # rUM 2.3.0 (rUM Swizzle)
 
 ## Enhancements

--- a/inst/gists/quarto_slides.qmd
+++ b/inst/gists/quarto_slides.qmd
@@ -9,6 +9,8 @@ date: last-modified
 date-format: "MMMM D, YYYY"
 format:
   revealjs:
+    link-external-newwindow: true
+    link-external-icon: false
     theme: 
       - default
       - slides.scss

--- a/inst/gists/quarto_slides_example_miami.qmd
+++ b/inst/gists/quarto_slides_example_miami.qmd
@@ -8,6 +8,8 @@ date: last-modified
 date-format: "MMMM D, YYYY"
 format: 
   revealjs:
+    link-external-newwindow: true
+    link-external-icon: false
     theme: [default, slides.scss]
     slideNumber: true
     fontsize: 2em

--- a/inst/gists/quarto_slides_example_rmed.qmd
+++ b/inst/gists/quarto_slides_example_rmed.qmd
@@ -9,6 +9,8 @@ date: last-modified
 date-format: "MMMM D, YYYY"
 format:
   revealjs:
+    link-external-newwindow: true
+    link-external-icon: false
     theme: 
       - default
       - slides.scss

--- a/inst/gists/quarto_slides_miami.qmd
+++ b/inst/gists/quarto_slides_miami.qmd
@@ -8,6 +8,8 @@ date: last-modified
 date-format: "MMMM D, YYYY"
 format: 
   revealjs:
+    link-external-newwindow: true
+    link-external-icon: false
     theme: [default, slides.scss]
     slideNumber: true
     fontsize: 2em

--- a/inst/gists/quarto_slides_rmed.qmd
+++ b/inst/gists/quarto_slides_rmed.qmd
@@ -9,6 +9,8 @@ date: last-modified
 date-format: "MMMM D, YYYY"
 format:
   revealjs:
+    link-external-newwindow: true
+    link-external-icon: false
     theme: 
       - default
       - slides.scss


### PR DESCRIPTION
  - Add link-external-newwindow: true to all revealjs slide templates
  - Set link-external-icon: false to suppress default icon
  - Bump version to 2.3.1, update NEWS.md
  - fixes #98